### PR TITLE
Use --no-document for gem installs

### DIFF
--- a/gemrc
+++ b/gemrc
@@ -5,4 +5,4 @@
 :update_sources: true
 :verbose: true
 benchmark: false
-gem: --no-ri --no-rdoc
+gem: --no-document


### PR DESCRIPTION
This disables the default documentation that comes with gems. I have no need for it locally. It used to be --no-ri --no-rdoc but it seems to have changed to be --no-document at somepoint.