### PR TITLE
Add ripgrep config

### DIFF
--- a/ripgreprc
+++ b/ripgreprc
@@ -1,0 +1,2 @@
+# https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file
+--smart-case

--- a/zshrc
+++ b/zshrc
@@ -119,3 +119,6 @@ export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 # fzf key bindings and fuzzy completion:
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+# ripgrep config location
+export RIPGREP_CONFIG_PATH=~/.ripgreprc


### PR DESCRIPTION
This comes from instructions here: https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file

TL;DR is you set a RIPGREP_CONFIG_PATH to a file where each line is passed to every ripgrep every time it's run