### PR TITLE
Switch path to be a function not alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -7,9 +7,6 @@ alias ll='ls -al'
 alias lh='ls -Alh'
 alias ffind='find . -name "*$1*"'
 
-# Pretty print the path
-alias path="echo $PATH | tr -s ':' '\n'"
-
 # git
 alias gb='git branch'
 alias gbb="git branch | grep -v '^*' | fzf | xargs git checkout"

--- a/functions
+++ b/functions
@@ -1,0 +1,4 @@
+# Pretty print the path
+function path {
+  echo $PATH | tr -s ':' '\n'
+}

--- a/zshrc
+++ b/zshrc
@@ -28,6 +28,11 @@ zstyle ':completion:*:*' ignored-patterns '*ORIG_HEAD'
 # set editor
 export EDITOR="code"
 
+# functions
+if [ -e "$HOME/.functions" ]; then
+  source "$HOME/.functions"
+fi
+
 # aliases
 if [ -e "$HOME/.aliases" ]; then
   source "$HOME/.aliases"


### PR DESCRIPTION
zsh aliases are expanded when their body is parsed, not when the alias is executed. That means if your alias prints out the contents of $PATH, anything added to the $PATH after setup won't be there. Instead I created a function that does the same thing but runs fresh every time.

Reference: http://zsh.sourceforge.net/Intro/intro_4.html